### PR TITLE
Double quotes causes Ansible to produce literal "\n" in authorized_keys

### DIFF
--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -35,7 +35,7 @@
 
 - name: Configure ~/.ssh/authorized_keys for users
   authorized_key:
-    key: '{{ item.sshkeys | join("\n") }}'
+    key: "{{ item.sshkeys | join('\n') }}"
     state: 'present'
     user: '{{ item.name }}'
   no_log: users_debug == false

--- a/tasks/ssh.yml
+++ b/tasks/ssh.yml
@@ -38,6 +38,7 @@
     key: "{{ item.sshkeys | join('\n') }}"
     state: 'present'
     user: '{{ item.name }}'
+    exclusive: 'yes'
   no_log: users_debug == false
   with_items: "{{ users_admin + users_normal }}"
   when: ((item.name is defined and item.name and item.name != 'root') and


### PR DESCRIPTION
Fixes #3